### PR TITLE
make chan faster by using dbly-linked-list instead of array

### DIFF
--- a/benchmark-results/benchmark.txt
+++ b/benchmark-results/benchmark.txt
@@ -1,47 +1,47 @@
-2021-05-23T23:16:37.899Z
+2021-05-24T18:08:18.579Z
 
 > chan
   > ops/sec
   >  30,000,000:  ...for comparison: plain array.  put.  items: 150,000
   >  30,000,000:  ...for comparison: plain array.  alternating put and get.  items: 150,000
-  >      59,928:  ...for comparison: plain array.  put and get in series.  items: 150,000
-  >   2,542,373:  chan: put.  items: 150,000
-  >   2,083,333:  chan: alternating put and get.  items: 150,000
-  >      60,338:  chan: put and get in series.  items: 150,000
-  >   1,704,545:  chan: put and get in parallel.  items: 150,000; capacity: 0
-  >   2,272,727:  chan: put and get in parallel.  items: 150,000; capacity: 1
-  >   2,343,750:  chan: put and get in parallel.  items: 150,000; capacity: 2
-  >   2,343,750:  chan: put and get in parallel.  items: 150,000; capacity: 5
-  >   2,380,952:  chan: put and get in parallel.  items: 150,000; capacity: 100
-  >   2,419,355:  chan: put and get in parallel.  items: 150,000; capacity: null
-  >      55,804:  chan: put, seal, and forEach in series.  items: 150,000
-  >   1,500,000:  chan: put, seal, and forEach in parallel.  items: 150,000; capacity: 0
-  >   1,546,392:  chan: put, seal, and forEach in parallel.  items: 150,000; capacity: 1
-  >   1,630,435:  chan: put, seal, and forEach in parallel.  items: 150,000; capacity: 2
-  >   1,578,947:  chan: put, seal, and forEach in parallel.  items: 150,000; capacity: 5
-  >   1,327,434:  chan: put, seal, and forEach in parallel.  items: 150,000; capacity: 100
-  >     110,457:  chan: put, seal, and forEach in parallel.  items: 150,000; capacity: null
+  >      59,713:  ...for comparison: plain array.  put and get in series.  items: 150,000
+  >   1,898,734:  chan: put.  items: 150,000
+  >   1,807,229:  chan: alternating put and get.  items: 150,000
+  >   1,612,903:  chan: put and get in series.  items: 150,000
+  >   1,515,152:  chan: put and get in parallel.  items: 150,000; capacity: 0
+  >   1,948,052:  chan: put and get in parallel.  items: 150,000; capacity: 1
+  >   1,923,077:  chan: put and get in parallel.  items: 150,000; capacity: 2
+  >   2,000,000:  chan: put and get in parallel.  items: 150,000; capacity: 5
+  >   1,807,229:  chan: put and get in parallel.  items: 150,000; capacity: 100
+  >   2,027,027:  chan: put and get in parallel.  items: 150,000; capacity: null
+  >   1,388,889:  chan: put, seal, and forEach in series.  items: 150,000
+  >   1,388,889:  chan: put, seal, and forEach in parallel.  items: 150,000; capacity: 0
+  >   1,401,869:  chan: put, seal, and forEach in parallel.  items: 150,000; capacity: 1
+  >   1,376,147:  chan: put, seal, and forEach in parallel.  items: 150,000; capacity: 2
+  >   1,315,789:  chan: put, seal, and forEach in parallel.  items: 150,000; capacity: 5
+  >   1,442,308:  chan: put, seal, and forEach in parallel.  items: 150,000; capacity: 100
+  >   1,304,348:  chan: put, seal, and forEach in parallel.  items: 150,000; capacity: null
 
 > conveyor
   > ops/sec
-  >  25,000,000:  ...for comparison: run sync function 100,000 times.
-  >  10,000,000:  ...for comparison: run async function 100,000 times.
-  >   1,030,928:  conveyor: 100,000 items, one at a time, synchronous.
-  >   1,010,101:  conveyor: 100,000 items, one at a time, async.
-  >     990,099:  conveyor: 100,000 items, sets of ten, synchronous.
-  >     900,901:  conveyor: 100,000 items, sets of ten, async.
-  >     297,619:  conveyor: 100,000 items, dump in without awaiting, synchronous.
-  >     320,513:  conveyor: 100,000 items, dump in without awaiting, async.
-  >     240,964:  conveyor: 100,000 items, dump in without awaiting, synchronous, priority.
-  >     311,526:  conveyor: 100,000 items, dump in without awaiting, async, priority.
+  >  50,000,000:  ...for comparison: run sync function 100,000 times.
+  >  11,111,111:  ...for comparison: run async function 100,000 times.
+  >   1,123,596:  conveyor: 100,000 items, one at a time, synchronous.
+  >   1,149,425:  conveyor: 100,000 items, one at a time, async.
+  >   1,234,568:  conveyor: 100,000 items, sets of ten, synchronous.
+  >   1,136,364:  conveyor: 100,000 items, sets of ten, async.
+  >     369,004:  conveyor: 100,000 items, dump in without awaiting, synchronous.
+  >     413,223:  conveyor: 100,000 items, dump in without awaiting, async.
+  >     327,869:  conveyor: 100,000 items, dump in without awaiting, synchronous, priority.
+  >     308,642:  conveyor: 100,000 items, dump in without awaiting, async, priority.
 
 > lock
   > ops/sec
-  >  50,000,000:  ...for comparison: run sync function 100,000 times.
+  >  20,000,000:  ...for comparison: run sync function 100,000 times.
   >  11,111,111:  ...for comparison: run async function 100,000 times.
-  >     877,193:  lock: 100,000 fns, one at a time, synchronous.
-  >     806,452:  lock: 100,000 fns, one at a time, async.
-  >     862,069:  lock: 100,000 fns, sets of ten, synchronous.
-  >     787,402:  lock: 100,000 fns, sets of ten, async.
-  >     290,698:  lock: 100,000 fns, dump in without awaiting, synchronous.
-  >     234,742:  lock: 100,000 fns, dump in without awaiting, async.
+  >     775,194:  lock: 100,000 fns, one at a time, synchronous.
+  >     862,069:  lock: 100,000 fns, one at a time, async.
+  >     952,381:  lock: 100,000 fns, sets of ten, synchronous.
+  >     952,381:  lock: 100,000 fns, sets of ten, async.
+  >     303,951:  lock: 100,000 fns, dump in without awaiting, synchronous.
+  >     286,533:  lock: 100,000 fns, dump in without awaiting, async.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test-chan": "jest src/test/chan.test.ts --verbose",
     "test-conveyor": "jest src/test/conveyor.test.ts --verbose",
     "test-lock": "jest src/test/lock.test.ts --verbose",
+    "test-ll": "jest src/test/linkedlist.test.ts --verbose",
     "depchart-basic": "mkdir   -p depchart && depchart `find src | grep .ts` --exclude src/index.ts src/decl/typings.d.ts `find src | grep '/example/'` `find src | grep '/test/'` `find src | grep '/benchmark'` --rankdir LR -o depchart/depchart-basic --node_modules separated",
     "depchart-all": "mkdir     -p depchart && depchart `find src | grep .ts` --exclude src/index.ts src/decl/typings.d.ts                                                                                         --rankdir LR -o depchart/depchart-all   --node_modules separated",
     "depchart": "yarn depchart-all && yarn depchart-basic",
@@ -37,6 +38,7 @@
   },
   "dependencies": {
     "@types/heap": "^0.2.28",
+    "dbly-linked-list": "^0.3.4",
     "heap": "^0.2.6"
   },
   "jest": {

--- a/src/test/chan.test.ts
+++ b/src/test/chan.test.ts
@@ -232,6 +232,7 @@ describe('all the different states', () => {
         // and grab the next waiting get and put
         // it into the queue
         expect(await chan3.get()).toBe(10);
+
         expect(chan3.itemsInQueue).toBe(3);
         expect(chan3.itemsInQueueAndWaitingPuts).toBe(5);
 

--- a/src/test/linkedlist.test.ts
+++ b/src/test/linkedlist.test.ts
@@ -1,0 +1,109 @@
+
+import 'jest';
+
+import LinkedList, { Node as LinkedListNode } from 'dbly-linked-list';
+import { removeLinkedListNode } from '../chan';
+
+//process.on('unhandledRejection', (reason : any, p : any) => {
+//    console.log('Unhandled Rejection at: Promise', p, 'reason:', reason);
+//});
+
+test('remove only', async () => {
+    let ll = new LinkedList();
+    expect(ll.getSize()).toBe(0);
+    ll.insert(0);
+    expect(ll.getSize()).toBe(1);
+    let n0 = ll.findAt(0);
+
+    removeLinkedListNode(ll, n0);
+    expect(ll.getHeadNode()).toBe(null);
+    expect(ll.getTailNode()).toBe(null);
+    expect(ll.getSize()).toBe(0);
+    expect(ll.toArray()).toStrictEqual([]);
+});
+
+test('remove head of 2', async () => {
+    let ll = new LinkedList();
+    expect(ll.getSize()).toBe(0);
+    ll.insert(0);
+    ll.insert(1);
+    expect(ll.getSize()).toBe(2);
+    let n0 = ll.findAt(0);
+    let n1 = ll.findAt(1);
+
+    removeLinkedListNode(ll, n0);
+    expect(ll.getHeadNode()).toBe(n1);
+    expect(ll.getTailNode()).toBe(n1);
+    expect(ll.getSize()).toBe(1);
+    expect(ll.toArray()).toStrictEqual([1]);
+});
+
+test('remove tail of 2', async () => {
+    let ll = new LinkedList();
+    expect(ll.getSize()).toBe(0);
+    ll.insert(0);
+    ll.insert(1);
+    expect(ll.getSize()).toBe(2);
+    let n0 = ll.findAt(0);
+    let n1 = ll.findAt(1);
+
+    removeLinkedListNode(ll, n1);
+    expect(ll.getHeadNode()).toBe(n0);
+    expect(ll.getTailNode()).toBe(n0);
+    expect(ll.getSize()).toBe(1);
+    expect(ll.toArray()).toStrictEqual([0]);
+});
+
+test('remove head of 3', async () => {
+    let ll = new LinkedList();
+    expect(ll.getSize()).toBe(0);
+    ll.insert(0);
+    ll.insert(1);
+    ll.insert(2);
+    expect(ll.getSize()).toBe(3);
+    let n0 = ll.findAt(0);
+    let n1 = ll.findAt(1);
+    let n2 = ll.findAt(2);
+
+    removeLinkedListNode(ll, n0);
+    expect(ll.getHeadNode()).toBe(n1);
+    expect(ll.getTailNode()).toBe(n2);
+    expect(ll.getSize()).toBe(2);
+    expect(ll.toArray()).toStrictEqual([1, 2]);
+});
+
+test('remove middle of 3', async () => {
+    let ll = new LinkedList();
+    expect(ll.getSize()).toBe(0);
+    ll.insert(0);
+    ll.insert(1);
+    ll.insert(2);
+    expect(ll.getSize()).toBe(3);
+    let n0 = ll.findAt(0);
+    let n1 = ll.findAt(1);
+    let n2 = ll.findAt(2);
+
+    removeLinkedListNode(ll, n1);
+    expect(ll.getHeadNode()).toBe(n0);
+    expect(ll.getTailNode()).toBe(n2);
+    expect(ll.getSize()).toBe(2);
+    expect(ll.toArray()).toStrictEqual([0, 2]);
+});
+
+test('remove tail of 3', async () => {
+    let ll = new LinkedList();
+    expect(ll.getSize()).toBe(0);
+    ll.insert(0);
+    ll.insert(1);
+    ll.insert(2);
+    expect(ll.getSize()).toBe(3);
+    let n0 = ll.findAt(0);
+    let n1 = ll.findAt(1);
+    let n2 = ll.findAt(2);
+
+    removeLinkedListNode(ll, n2);
+    expect(ll.getHeadNode()).toBe(n0);
+    expect(ll.getTailNode()).toBe(n1);
+    expect(ll.getSize()).toBe(2);
+    expect(ll.toArray()).toStrictEqual([0, 1]);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1186,6 +1186,13 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+dbly-linked-list@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/dbly-linked-list/-/dbly-linked-list-0.3.4.tgz#e4f85b79f303808d01a19336c9475abd0aa4f82e"
+  integrity sha512-327vOlwspi9i1T3Kc9yZhRUR8qDdgMQ4HmXsFDDCQ/HTc3sNe7gnF5b0UrsnaOJ0rvmG7yBZpK0NoOux9rKYKw==
+  dependencies:
+    lodash.isequal "^4.5.0"
+
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -2594,6 +2601,11 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"


### PR DESCRIPTION
Replace internal arrays (_queue, _waitingGets, _waitingPuts) with linked lists.

This makes Chan have O(1) performance even when the queue is very long, or there are a lot of waiting gets or puts (e.g. > 100,000).

Performance on small test cases is about the same.

Downside: another dependency, which itself has a dependency on `lodash.isEqual`, and slightly less easy to read code.